### PR TITLE
docs: add extra permissions for EKS addon installation

### DIFF
--- a/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.md
+++ b/docs/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.md
@@ -88,12 +88,13 @@ This [tutorial](https://aws.amazon.com/blogs/opensource/managing-eks-clusters-ra
 
 ## Minimum EKS Permissions
 
-These are the minimum set of permissions necessary to access the full functionality of Rancher's EKS driver. You'll need additional permissions for Rancher to provision the `Service Role` and `VPC` resources. If you create these resources **before** you create the cluster, they'll be available when you configure the cluster.
+These are the minimum set of permissions necessary to access the full functionality of Rancher's EKS driver. You'll need additional permissions for Rancher to provision the `Service Role` and `VPC` resources. If you create these resources **before** you create the cluster, they'll be available when you configure the cluster. Additionally, starting with EKS v1.23 you are required to use the out-of-tree drivers for EBS backed volumes and you will need specific permissions to enable the add-on.
 
 Resource | Description
 ---------|------------
 Service Role | Provides permissions that allow Kubernetes to manage resources on your behalf. Rancher can create the service role with the following [Service Role Permissions](#service-role-permissions).
 VPC | Provides isolated network resources utilised by EKS and worker nodes. Rancher can create the VPC resources with the following [VPC Permissions](#vpc-permissions).
+EBS CSI Driver add-on | Provides permissions that allow Kubernetes to interact with EBS and configure the cluster to enable the add-on. Rancher can install the add-on with the following [EBS CSI Driver addon Permissions](#ebs-csi-driver-addon-permissions).
 
 
 Resource targeting uses `*` as the ARN of many of the resources created cannot be known before creating the EKS cluster in Rancher.
@@ -305,6 +306,43 @@ These are permissions that are needed by Rancher to create a Virtual Private Clo
       "Resource": "*"
     }
   ]
+}
+```
+
+### EBS CSI Driver addon Permissions
+
+Permissions required for Rancher to install the Amazon EBS CSI Driver add-on.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "eks:DescribeAddonConfiguration",
+                "eks:UpdateAddon",
+                "eks:ListAddons",
+                "iam:CreateRole",
+                "iam:AttachRolePolicy",
+                "eks:DescribeAddon",
+                "iam:CreateOpenIDConnectProvider",
+                "iam:PassRole",
+                "eks:DescribeIdentityProviderConfig",
+                "eks:DeleteAddon",
+                "iam:ListOpenIDConnectProviders",
+                "iam:ListAttachedRolePolicies",
+                "eks:CreateAddon",
+                "eks:DescribeCluster",
+                "eks:DescribeAddonVersions",
+                "sts:AssumeRoleWithWebIdentity",
+                "eks:AssociateIdentityProviderConfig",
+                "eks:ListIdentityProviderConfigs"
+            ],
+            "Resource": "*"
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
Add extra permissions for EKS policy as this is required for enabling the EBS CSI Driver addon, which is introduced to support EBS-backed volumes.

More context on this functionality can be found in rancher/eks-operator#170